### PR TITLE
Allow pyodk to be configured via environment variable and CentralConfig object

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,22 @@ The `Client` is specific to a configuration and cache file. These approximately 
 - Setting environment variables `PYODK_CONFIG_FILE` and `PYODK_CACHE_FILE`
 - Init arguments: `Client(config_path="my_config.toml", cache_path="my_cache.toml")`.
 
+### Environment variables
+
+Alternatively, instead of a config file, it is possible to use environment variables for configuration.
+
+The available options are:
+
+```dotenv
+# If one is set, they must all be set
+PYODK_BASE_URL=https://example.com
+PYODK_USERNAME=user@example.com
+PYODK_PASSWORD=yourpassword
+
+# Optional variable
+PYODK_DEFAULT_PROJECT_ID=1
+```
+
 ### Default project
 
 The `Client` is not specific to a project, but a default `project_id` can be set by:

--- a/pyodk/_utils/config.py
+++ b/pyodk/_utils/config.py
@@ -43,19 +43,21 @@ def objectify_config(config_data: dict) -> Config:
     Convert a config dict into objects to validate the data.
     """
     central = CentralConfig(**config_data["central"])
-    config = Config(central=central)
-    return config
+    return Config(central=central)
 
 
 def get_path(path: str, env_key: str) -> Path:
     """
     Get a path from the path argument, the environment key, or the default.
     """
+    # Manually specified path
     if path is not None:
         return Path(path)
     env_file_path = os.environ.get(env_key)
+    # User specified path from env var
     if env_file_path is not None:
         return Path(env_file_path)
+    # Use default ./.pyodk_config.toml
     return defaults[env_key]
 
 
@@ -82,11 +84,44 @@ def read_toml(path: Path) -> dict:
 
 def read_config(config_path: str | None = None) -> Config:
     """
-    Read the config file.
+    Read the config from the user environment or config file.
+
+    The following priority is used:
+    1. Environment variables
+    2. User-specified config file
+    3. Default config file `.pyodk_config.toml`
+    4. Error if no valid configuration is found
     """
-    file_path = get_path(path=config_path, env_key="PYODK_CONFIG_FILE")
-    file_data = read_toml(path=file_path)
-    return objectify_config(config_data=file_data)
+    # First, check if all three environment variables are present
+    env_config = {
+        "central": {
+            "base_url": os.getenv("PYODK_BASE_URL"),
+            "username": os.getenv("PYODK_USERNAME"),
+            "password": os.getenv("PYODK_PASSWORD"),
+        }
+    }
+
+    default_project_id = os.getenv("PYODK_DEFAULT_PROJECT_ID")
+    if default_project_id:  # Include optional `default_project_id` key, only if it's set
+        env_config["central"]["default_project_id"] = default_project_id
+
+    if all(env_config["central"].values()):
+        return objectify_config(config_data=env_config)
+
+    # Next, check credentials from config file
+    file_path = get_config_path(config_path)
+    if file_path.exists():
+        file_data = read_toml(file_path)
+        return objectify_config(config_data=file_data)
+
+    # Finally, if no configuration then error
+    err_msg = (
+        "No valid configuration found. Please provide a config file "
+        "or set the required environment variables. "
+        "See https://github.com/getodk/pyodk?tab=readme-ov-file#configure for details."
+    )
+    log.error(err_msg)
+    raise PyODKError(err_msg)
 
 
 def read_cache_token(cache_path: str | None = None) -> str:

--- a/pyodk/client.py
+++ b/pyodk/client.py
@@ -30,13 +30,17 @@ class Client:
 
     def __init__(
         self,
-        config_path: str | None = None,
+        config_path: str | config.CentralConfig | None = None,
         cache_path: str | None = None,
         project_id: int | None = None,
         session: Session | None = None,
         api_version: str | None = "v1",
     ) -> None:
-        self.config: config.Config = config.read_config(config_path=config_path)
+        # NOTE config_path is named a such to avoid breaking the API
+        if isinstance(config_path, config.CentralConfig):
+            self.config: config.Config = config.Config(central=config_path)
+        else:
+            self.config: config.Config = config.read_config(config_path=config_path)
         self._project_id: int | None = project_id
         if session is None:
             session = Session(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -162,7 +162,10 @@ class TestConfig(TestCase):
         }
         with (
             patch.dict(os.environ, cfg, clear=True),
-            patch("pyodk._utils.config.get_config_path", return_value=Path(resources.CONFIG_FILE)),
+            patch(
+                "pyodk._utils.config.get_config_path",
+                return_value=Path(resources.CONFIG_FILE),
+            ),
             patch(
                 "pyodk._utils.config.read_toml",
                 return_value={

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -92,3 +93,94 @@ class TestConfig(TestCase):
         self.assertEqual(
             "Config value 'password' must not be empty.", err.exception.args[0]
         )
+
+    def test_read_envvars____ok__required_vars_present(self):
+        """Successfully reads environment variables as PyOdk config."""
+        cfg = {
+            "PYODK_BASE_URL": "https://env.vars.config.com",
+            "PYODK_USERNAME": "user@env.vars.config.com",
+            "PYODK_PASSWORD": "DifferentPassword",
+        }
+
+        with patch.dict(os.environ, cfg, clear=True):
+            new_config = config.read_config()
+            self.assertEqual(new_config.central.base_url, cfg["PYODK_BASE_URL"])
+            self.assertEqual(new_config.central.username, cfg["PYODK_USERNAME"])
+            self.assertEqual(new_config.central.password, cfg["PYODK_PASSWORD"])
+
+    def test_read_envvars__error_missing_required_env_var(self):
+        """Raise an error when no config is provided and required env vars are missing."""
+        cfg = {
+            "PYODK_USERNAME": "https://env.vars.config.com",
+            "PYODK_PASSWORD": "user@env.vars.config.com",
+            # Missing PYODK_BASE_URL
+        }
+        with patch.dict(os.environ, cfg, clear=True):
+            with self.assertRaises(PyODKError) as err:
+                config.read_config()
+            self.assertIn("No valid configuration found", str(err.exception))
+
+    def test_read_envvars__ok__with_empty_default_project_id(self):
+        """All required env vars are set, but PYODK_DEFAULT_PROJECT_ID is empty string."""
+        cfg = {
+            "PYODK_BASE_URL": "https://env.vars.config.com",
+            "PYODK_USERNAME": "user@env.vars.config.com",
+            "PYODK_PASSWORD": "DifferentPassword",
+            "PYODK_DEFAULT_PROJECT_ID": "",  # Empty string should be ignored
+        }
+        with patch.dict(os.environ, cfg, clear=True):
+            conf = config.read_config()
+            self.assertEqual(conf.central.base_url, cfg["PYODK_BASE_URL"])
+            self.assertEqual(conf.central.username, cfg["PYODK_USERNAME"])
+            self.assertEqual(conf.central.password, cfg["PYODK_PASSWORD"])
+            self.assertEqual(conf.central.default_project_id, None)
+
+    def test_read_envvars__ok__with_valid_default_project_id(self):
+        """Return config and include PYODK_DEFAULT_PROJECT_ID when it is provided."""
+        cfg = {
+            "PYODK_BASE_URL": "https://env.vars.config.com",
+            "PYODK_USERNAME": "user@env.vars.config.com",
+            "PYODK_PASSWORD": "DifferentPassword",
+            "PYODK_DEFAULT_PROJECT_ID": "123",
+        }
+        with patch.dict(os.environ, cfg, clear=True):
+            conf = config.read_config()
+            self.assertEqual(conf.central.base_url, cfg["PYODK_BASE_URL"])
+            self.assertEqual(conf.central.username, cfg["PYODK_USERNAME"])
+            self.assertEqual(conf.central.password, cfg["PYODK_PASSWORD"])
+            self.assertEqual(
+                conf.central.default_project_id, cfg["PYODK_DEFAULT_PROJECT_ID"]
+            )
+
+    def test_read_config__ok__env_vars_take_precedence(self):
+        """If env vars are present, they take precedence over a specified config file."""
+        cfg = {
+            "PYODK_BASE_URL": "https://env.vars.config.com",
+            "PYODK_USERNAME": "user@env.vars.config.com",
+            "PYODK_PASSWORD": "DifferentPassword",
+            "PYODK_DEFAULT_PROJECT_ID": "123",
+        }
+        with (
+            patch.dict(os.environ, cfg, clear=True),
+            patch("pyodk._utils.config.get_config_path", return_value=Path(resources.CONFIG_FILE)),
+            patch(
+                "pyodk._utils.config.read_toml",
+                return_value={
+                    "central": {
+                        "base_url": "https://file.config.com",
+                        "username": "file_user",
+                        "password": "FilePassword",
+                        "default_project_id": "999",
+                    }
+                },
+            ),
+        ):
+            conf = config.read_config(config_path=resources.CONFIG_FILE)
+
+            # Env vars should take precedence
+            self.assertEqual(conf.central.base_url, cfg["PYODK_BASE_URL"])
+            self.assertEqual(conf.central.username, cfg["PYODK_USERNAME"])
+            self.assertEqual(conf.central.password, cfg["PYODK_PASSWORD"])
+            self.assertEqual(
+                conf.central.default_project_id, cfg["PYODK_DEFAULT_PROJECT_ID"]
+            )


### PR DESCRIPTION
**This PR should not be merged, it is here to more visually show code changes**

- Added option to configure pyodk by 4 environment variables, matching the config TOML file options.
- Also allow conguration by directly passing a CentralConfig object as `config_path` (named as such to avoid breaking API)
- The order of priority is:
  - Directly passed CentralConfig object.
  - Environment variables.
  - User specified config file, if valid file.
  - Default config file, if valid file.
  - Error if none of the above present.
- The environment variables are:
    ```dotenv
    # If one is set, they must all be set
    PYODK_BASE_URL=https://example.com
    PYODK_USERNAME=user@example.com
    PYODK_PASSWORD=yourpassword
        
    # Optional variable
    PYODK_DEFAULT_PROJECT_ID=1
    ```